### PR TITLE
Pin transitive Netty and Jackson versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,13 @@ dependencies {
     hivemqProvided(libs.logback.classic)
     implementation(libs.azure.storage.blob)
     implementation(libs.owner.java8)
+
+    implementation(platform(libs.netty.bom)) {
+        because("pin fixed netty-bom version for vulnerability described in INT-261")
+    }
+    implementation(platform(libs.jackson.bom)) {
+        because("pin fixed jackson-core version for vulnerability described in INT-261")
+    }
 }
 
 oci {
@@ -98,11 +105,11 @@ testing {
                 testTask {
                     testLogging {
                         events = setOf(
-                            TestLogEvent.STARTED,
-                            TestLogEvent.PASSED,
-                            TestLogEvent.SKIPPED,
-                            TestLogEvent.FAILED,
-                            TestLogEvent.STANDARD_ERROR,
+                                TestLogEvent.STARTED,
+                                TestLogEvent.PASSED,
+                                TestLogEvent.SKIPPED,
+                                TestLogEvent.FAILED,
+                                TestLogEvent.STANDARD_ERROR,
                         )
                         exceptionFormat = TestExceptionFormat.FULL
                         showStandardStreams = true
@@ -124,6 +131,13 @@ testing {
                 implementation(libs.gradleOci.junitJupiter)
                 implementation(libs.azure.storage.blob)
                 runtimeOnly(libs.logback.classic)
+
+                implementation(platform(libs.netty.bom)) {
+                    because("pin fixed netty-bom version for vulnerability described in INT-261")
+                }
+                implementation(platform(libs.jackson.bom)) {
+                    because("pin fixed jackson-core version for vulnerability described in INT-261")
+                }
             }
             oci.of(this) {
                 imageDependencies {
@@ -170,7 +184,7 @@ tasks.withType<AbstractArchiveTask>().configureEach {
 tasks.withType<JavaCompile>().configureEach {
     // ensure consistent compilation across different JDK versions
     options.compilerArgs.addAll(listOf(
-        // include parameter names for reflection (improves consistency)
-        "-parameters"
+            // include parameter names for reflection (improves consistency)
+            "-parameters"
     ))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,10 +4,12 @@ awaitility = "4.3.0"
 azure-storage-blob = "12.33.3"
 gradleOci-junitJupiter = "0.8.0"
 hivemq-extensionSdk = "4.7.5"
+jackson = "2.21.2"
 jetbrains-annotations = "26.1.0"
 junit-jupiter = "5.10.0"
 logback = "1.5.32"
 mockito = "5.23.0"
+netty = "4.1.132.Final"
 owner = "1.0.12"
 testcontainers = "2.0.5"
 
@@ -16,9 +18,11 @@ assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 azure-storage-blob = { module = "com.azure:azure-storage-blob", version.ref = "azure-storage-blob" }
 gradleOci-junitJupiter = { module = "io.github.sgtsilvio:gradle-oci-junit-jupiter", version.ref = "gradleOci-junitJupiter" }
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
 owner-java8 = { module = "org.aeonbits.owner:owner-java8", version.ref = "owner" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-hivemq = { module = "org.testcontainers:testcontainers-hivemq", version.ref = "testcontainers" }


### PR DESCRIPTION
Applies netty-bom 4.1.132.Final and jackson-bom 2.21.2 as platform constraints to the main and integrationTest configurations, bumping the versions pulled in transitively by azure-storage-blob until an upstream patch is available.